### PR TITLE
Travis をやめて GitHub Actions をつかう

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,10 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.1.9', '2.2.10']
+        ruby-version: ['2.1.9']
 
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    - name: install middlewares
+      run: |
+        apt-get update -qq
+        apt-get install -y zlib1g-dev liblzma-dev patch
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['1.9', '2.0', '2.1', '2.2']
+        ruby-version: ['2.1.9', '2.2.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['1.9', '2.0', '2.1', '2.2']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: make travis

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,7 +34,7 @@ jobs:
     - name: install middlewares
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y zlib1g-dev liblzma-dev patch libxslt1-dev
+        sudo apt-get install -y libxslt1-dev
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,7 +34,7 @@ jobs:
     - name: install middlewares
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y zlib1g-dev liblzma-dev patch
+        sudo apt-get install -y zlib1g-dev liblzma-dev patch libxslt1-dev
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,8 +33,8 @@ jobs:
 
     - name: install middlewares
       run: |
-        apt-get update -qq
-        apt-get install -y zlib1g-dev liblzma-dev patch
+        sudo apt-get update -qq
+        sudo apt-get install -y zlib1g-dev liblzma-dev patch
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-nguage: ruby
-rvm: 
-    - 2.2.0
-    - 2.1.0
-    - 2.0.0
-    - 1.9.3
-script: make travis


### PR DESCRIPTION
2021/03 末で全社的に Travis を使わないことになった。

ref. https://cartaholdings.slack.com/archives/C02ACV8H0/p1614231195006200

これに対応する。